### PR TITLE
Refactor: Removing sceneManager, de-coupling MyContents from MyApp

### DIFF
--- a/projects/racingGame/sceneManager.js
+++ b/projects/racingGame/sceneManager.js
@@ -8,6 +8,7 @@ class SceneManager {
 
     constructor(app) {
 
+        
         this.scenes       = new Map();
         this.currentScene = 'race';
         this.app          = app;
@@ -31,9 +32,8 @@ class SceneManager {
         });
 
         
-        this.app.resetScene()
-        
-        let reader = new MyFileReader(this.app);
+        this.app.resetScene();
+        let reader = new MyFileReader();
         let xmlData;
         
         await fetch(yafxOutput).then((response) => {
@@ -50,10 +50,8 @@ class SceneManager {
         await contents.onSceneLoaded(reader.data)
         contents.loadModels();
 
-        
-        
-        contents.startScene()
-        contents.init()
+        this.app.startScene()
+        this.app.init()
 
         return contents;
     }

--- a/src/engine/MyApp.js
+++ b/src/engine/MyApp.js
@@ -5,6 +5,14 @@ import { MyContents } from './MyContents.js';
 import { MyGuiInterface } from './MyGuiInterface.js';
 import Stats from 'three/addons/libs/stats.module.js'
 import { SceneManager } from './projects/racingGame/sceneManager.js';
+import { MyFileReader } from '../../parser/MyFileReader.js';
+
+import * as raceScene from './scenes/race.js';
+import * as menuScene from './scenes/menu.js';
+import * as testScene from './scenes/test.js';
+import * as resultsScene from './scenes/results.js';
+
+
 
 /**
  * This class contains the application object
@@ -14,15 +22,35 @@ class MyApp {
      * the constructor
      */
     constructor() {
-        this.scene = null
         this.stats = null
 
+        this.scenes       = new Map();
+        this.currentScene = 'race';
+        this.app          = app;
+        this.scenes.set("race", raceScene);
+        this.scenes.set("menu", menuScene);
+        this.scenes.set("test", testScene);
+        this.scenes.set("results", resultsScene);
+        
+        this.project = null
         this.clock     = new THREE.Clock();
         this.raycaster = new THREE.Raycaster()
         this.raycaster.near = 1
         this.raycaster.far = 100
+        this.collisionQueue = null;
+
+        this.usePhysics = false;
+        this.paused = false;
+        this.loading = false;
+        this.narrowDistance = null;
+        this.shadowsOn = true;
+        this.physics = null
+        this.rapier = null
 
         this.pointer   = new THREE.Vector2()
+        this.eventMap = new Map();
+        this.eventQueue = [];
+        this.clickIntersects = []
 
         // camera related attributes
         this.activeCamera = null
@@ -36,15 +64,10 @@ class MyApp {
         this.controls = null
         this.gui = null
         this.axis = null
-        this.contents = new MyContents(this)
-        this.sceneManager = new SceneManager(this);
+        this.contents = new MyContents()
 
     }
 
-    resetScene() {
-        this.scene = new THREE.Scene();
-        this.scene.background = new THREE.Color(0x101010);
-    }
 
     /**
      * initializes the application
@@ -52,8 +75,7 @@ class MyApp {
     init() {
 
         // Create an empty scene
-        this.scene = new THREE.Scene();
-        this.scene.background = new THREE.Color(0x101010);
+
         
         this.stats = new Stats()
         this.stats.showPanel(1) // 0: fps, 1: ms, 2: mb, 3+: custom
@@ -85,17 +107,58 @@ class MyApp {
 
     }
 
-    changeScene(sceneName, context) {
+    loadScenesFromProject(project) {
 
-        this.sceneManager.loadScene(sceneName, this.contents, context)
+        // complete here 
+    }
+
+    async changeScene(sceneName, context) {
+
+
+        const yafxScenes = "./projects/";
+        const project    = "racingGame";
+        const yafxOutput = yafxScenes + `${project}/scenes/${sceneName}.xml`;
+        
+        const scene = this.scenes.get(sceneName)
+
+        await fetch(yafxOutput, {
+            method: "PUT",
+            body: scene.create(context),
+        });
+
+        
+        this.app.resetScene();
+        let reader = new MyFileReader();
+        let xmlData;
+        
+        await fetch(yafxOutput).then((response) => {
+            return response.text();
+        }).then((data) => {
+            xmlData = data;
+        });
+        
+        
+        let parser = new window.DOMParser();
+        reader.xmlDoc = parser.parseFromString(xmlData, "text/xml");
+        this.contents.reset();
+        await reader.readXML();
+        await this.contents.onSceneLoaded(reader.data)
+        this.contents.loadModels();
+
+        this.startScene()
+        this.init()
+
+        return contents;
 
     }
 
 
     addCamera(camera, cameraName) {
+
         this.cameras[cameraName] = camera
-        this.scene.add(camera)
+        this.contents.scene.add(camera)
     }
+
     setCameras(cameras, activeCameraId) {
         const aspect = window.innerWidth / window.innerHeight;
 
@@ -115,7 +178,7 @@ class MyApp {
             this.cameras[key] = newCamera
             newCamera.position.set(camera.location[0], camera.location[1], camera.location[2])
             newCamera.lookAt(new THREE.Vector3(camera.target[0], camera.target[1], camera.target[2]))
-            this.scene.add(newCamera)
+            this.contents.scene.add(newCamera)
         }
 
         this.setActiveCamera(activeCameraId)
@@ -141,13 +204,13 @@ class MyApp {
         //set the picking ray from the camera position and mouse coordinates
         this.raycaster.setFromCamera(this.pointer, this.activeCamera);
 
-        for (var key in this.scene.children) {
+        for (var key in this.contents.scene.children) {
 
-            var child = this.scene.children[key];
+            var child = this.contents.scene.children[key];
             if (child instanceof THREE.Group) {
 
-                var intersects = this.raycaster.intersectObjects(this.scene.children);
-                this.contents.generateClicks(intersects);
+                var intersects = this.raycaster.intersectObjects(this.contents.scene.children);
+                this.generateClicks(intersects);
                 break;
             }
         }
@@ -276,8 +339,282 @@ class MyApp {
     }
 
     /**
+     *  imported content from the MyContents class starts here
+     */
+
+    setPhysicsOn() {
+        this.usePhysics = true;
+        this.collisionQueue = new this.rapier.EventQueue(true);
+        this.collisionQueue.drainCollisionEvents((handle1, handle2, started) => {
+            this.eventQueue.push("aa");
+        });
+    }
+
+    generateClicks(content) {
+        let visited = new Set();
+
+        for (const intersect of content) {
+            let targetNode = intersect.object;
+            while (targetNode.parent) {
+                if (this.contents.nodes.has(targetNode.id) && visited.has(targetNode.id) == false) {
+                    console.log("onClick-" + this.content.nodes.get(targetNode.id));
+                    this.eventQueue.push("onClick-" + this.content.nodes.get(targetNode.id));
+                    visited.add(targetNode.id);
+
+                }
+                targetNode = targetNode.parent;
+            }
+        }
+
+        this.clickIntersects = content;
+
+    }
+
+    removeAllChildren(object) {
+        for (const child of object.children) {
+            this.removeAllChildren(child);
+        }
+
+        for (let [key, value] of this.objects.entries()) {
+            if (value === object) {
+                this.objects.delete(key);
+                this.controllers.delete(value);
+                break;
+            }
+        }
+
+    }
+
+
+    removeObject(object) {
+        if (object.parent)
+            object.parent.remove(object);
+        else this.contents.scene.remove(object);
+        this.removeAllChildren(object);
+    }
+
+
+
+    getObject(id) {
+        return this.objects.get(id);
+    }
+
+    pushEvent(event) {
+        this.eventQueue.push(event);
+    }
+
+    registerListener(event, listener) {
+
+        if (!this.eventMap.has(event)) {
+            this.eventMap.set(event, []);
+        }
+        this.eventMap.get(event).push(listener);
+    }
+
+    removeListener(event, listener) {
+        if (this.eventMap.has(event)) {
+            const listeners = this.eventMap.get(event);
+            const index = listeners.indexOf(listener);
+            if (index > -1) {
+                listeners.splice(index, 1);
+            }
+        }
+    }
+
+    
+    changeHUD(hud) {
+
+        const camera = this.activeCameraName;
+        this.cameraHuds.set(camera, this.huds.get(hud));
+
+    }
+
+    changeCamera(camera) {
+        this.setActiveCamera(camera);
+    }
+
+    changeScene(scene) {
+
+
+        let root = this.objects.get(this.rootId);
+        let rootController = this.controllers.get(root);
+        this.changeScene(scene, rootController.exports);
+        this.loading = true;
+
+    }
+    
+    getParams() {
+
+        if (this.params === null || this.params === undefined) {
+            this.params = {
+                object: null,
+                otherObject: null,
+                mixer: null,
+                input: this.keys,
+                aliasTable: this.contents.alias,
+                eventQueue: this.eventQueue,
+                eventMap: this.eventMap,
+                camera: this.activeCamera,
+                clock: this.clock,
+                updateDelta: this.clock.getDelta(),
+                renderer: this.renderer,
+                scene: this.contents.scene,
+                textRenderer: this.contents.fonts.get("default"),
+                ENGINE: {
+                    pushEvent:    this.pushEvent.bind(this),
+                    registerListener: this.registerListener.bind(this),
+                    removeListener:   this.removeListener.bind(this),
+                    removeObject:     this.removeObject.bind(this),
+                    addCamera:        this.addCamera.bind(this),
+                    changeScene:      this.changeScene.bind(this),
+                    changeHUD:        this.changeHUD.bind(this),
+                    changeCamera:     this.changeCamera.bind(this),
+                    getObject:        this.getObject.bind(this),
+
+                    newText: (renderer, text) => {return new MyTextSquare(renderer, text)},
+                    getEnv: (id) =>              { return this.envs.get(id) },
+                    getClickIntersects: () =>    { return this.clickIntersects },
+                    getMaterial: (id) =>         { return this.materials.get(id) },
+                    getNode: (id) =>             { return this.nodes.get(id) },
+                    setObject: (id, object) =>   { this.objects.set(id, object) },
+                }
+            };
+        }
+
+        return this.params;
+    }
+
+    startObjects() {
+
+        if (!this.contents.modelsLoaded)
+            return;
+
+        let params = this.getParams();
+
+        for (const [object, controller] of this.contents.controllers.entries()) {
+
+            params.object = object;
+            params.mixer = this.mixers.get(object.id);
+            controller.onStart(params);
+        }
+
+        this.modelsStarted = true;
+
+    }
+    startScene() {
+
+        this.createScene();
+        this.startObjects();
+        this.setCameras(this.contents.cameras, this.contents.activeCameraId)
+
+    }
+
+
+    triggerEvents() {
+
+        for (const event of this.eventQueue) {
+            let eventName = "";
+
+            if (typeof event == "string") {
+
+                eventName = event;
+            }
+            else {
+                eventName = event.name;
+            }
+            const listeners = this.eventMap.get(eventName);
+
+            if (listeners) {
+                for (const listener of listeners) {
+                    listener(event);
+                }
+            }
+        }
+
+        this.eventQueue = [];
+        this.clickIntersects = [];
+
+    }
+
+    updateCamera() {
+
+        const controls = this.controls;
+        const camera = this.activeCamera;
+        const cameraId = this.activeCameraName;
+        const controller = this.contents.cameraControllers.get(cameraId);
+        const hud = this.contents.cameraHuds.get(cameraId);
+
+
+        if (controller)
+            controller.onUpdate({ camera: camera, controls: controls, hud: hud});
+
+    }
+
+    updateObjects() {
+
+        let params = this.getParams()
+
+        for (const [object, controller] of this.controllers.entries()) {
+
+            params.object = object;
+            params.mixer = this.mixers.get(object.id);
+            params.textRenderer = this.fonts.get("default");
+            controller.onUpdate(params);
+        }
+    }
+
+    updateParticles() {
+
+        const aliveParticles = [];
+        for (const particle of this.particles) {
+            if (!particle.isDone()) {
+                particle.update(this.app.clock);
+                aliveParticles.push(particle);
+            }
+            else {
+                const mesh = particle.mesh;
+                mesh.parent.remove(mesh);
+            }
+        }
+        this.particles = aliveParticles;
+    }
+
+    runUpdatables() {
+
+        for (const updatable of this.updatables) {
+            updatable.run();
+        }
+
+    }
+
+    handleCollisions() {
+        if (this.usePhysics)
+            this.physics.step(this.collisionQueue);
+        else this.checkCollisions();
+    }
+
+    update() {
+        this.params = null;
+        if (!this.modelsStarted) {
+            this.startObjects();
+            return;
+        }
+
+        if (this.paused || this.loading) return;
+
+        this.runUpdatables();
+        this.handleCollisions();
+        this.triggerEvents();
+        this.updateParticles();
+        this.updateCamera();
+        this.updateObjects();
+
+    }
+
+    /**
     * the main render function. Called in a requestAnimationFrame loop
     */
+
     render() {
         this.stats.begin()
         this.updateCameraIfRequired()
@@ -293,7 +630,7 @@ class MyApp {
 
         // render the scene
 
-        this.renderer.render(this.scene, this.activeCamera);
+        this.renderer.render(this.contents.scene, this.activeCamera);
   
 
         // subsequent async calls to the render loop

--- a/src/engine/main.js
+++ b/src/engine/main.js
@@ -11,9 +11,8 @@ let gravity = { x: 0.0, y: -9.81, z: 0.0 };
 app.contents.rapier = RAPIER;
 app.contents.physics = new RAPIER.World(gravity);
 
-contents = await app.sceneManager.loadScene("menu", app.contents)
+await app.loadScene("menu", app.contents)
 
-app.setContents(contents)
 gui = new MyGuiInterface(app);
 gui.setContents(contents)
 gui.init()

--- a/src/parser/MyFileReader.js
+++ b/src/parser/MyFileReader.js
@@ -24,12 +24,8 @@ import { MySceneData } from './MySceneData.js';
 
 class MyFileReader  {
 
-    /**
-       constructs the object
-       @param {MyApp} app The application object
-    */ 
-    constructor(app) {
-        this.app = app
+    constructor() {
+		
         this.xmlhttp = null;
         this.xmlDoc = null;
         this.xmlloaded = false;	


### PR DESCRIPTION
This commit features various changes:
- First, MyContents is now decoupled from MyApp. It does not call methods from MyApp anymore, and its functional role relies on storing information about the scene its presenting
- SceneManager was a class that contained only one function, which seemed like a code smell. After reviewing its purpose, it was clear that this was a part of the Engine and not of a given project. Instead, a project should provide a set of scenes for the Engine to read and store their relations, which will be dealt with later.
- MyFileReader does not need MyApp anymore to provide the data to MyContents.
- Update Loop now comes from MyApp, storing all the Engine endpoints and becoming the driving force of Link.

The following image exemplifies what was done in this commit:

![Untitled Diagram drawio](https://github.com/link-engine/link/assets/72610584/b7ccfa28-0419-45f4-ae56-02b3a16f31b5)


Closes #2 